### PR TITLE
Add Python 3.12 and 3.13 to CI test suite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - "db_query_profiler/**"
       - "tests/**"
+      - ".github/**"
       - uv.lock
       - .pre-commit-config.yaml
 
@@ -19,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest", "macos-latest", "ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: 🛎️ Check out repository

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![Python](https://img.shields.io/badge/Python-3.7+-blue.svg)](https://www.python.org/downloads/release/python-370/)
+[![Python](https://img.shields.io/badge/Python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![tests](https://github.com/Bilbottom/db-query-profiler/actions/workflows/tests.yaml/badge.svg)](https://github.com/Bilbottom/db-query-profiler/actions/workflows/tests.yaml)
 [![coverage](https://raw.githubusercontent.com/Bilbottom/db-query-profiler/main/coverage.svg)](https://github.com/dbrgn/coverage-badge)


### PR DESCRIPTION
## Summary by Sourcery

Update CI test suite and project documentation to support Python 3.12 and 3.13

CI:
- Add Python 3.12 and 3.13 to the GitHub Actions test matrix to ensure compatibility with the latest Python versions

Documentation:
- Update Python version badge in README to reflect minimum supported Python version as 3.8+